### PR TITLE
Change line endings to \n

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ log(chkDim(`source glob - ${src_glob}`));
 log(chkDim(`destination - ${dir_out}`));
 log(chkDim('--------------------------------------------------------------'));
 
-/* 
+/*
 cpx will copy the whole structure as is,
 while passing each file through a transform stream (less to css stream) and parsing each file to css.
 this didn't changed the .less extension, we will change it later on.


### PR DESCRIPTION
At present, the module does not work on macOS due to a \r after /bin/env:
```
lessc-glob [master] ./index.js
env: node\r: No such file or directory

```

This PR changes line endings to \n which do work