### PR TITLE
Updated Lessc stream and made less a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
   },
   "homepage": "https://github.com/sag1v/lessc-glob",
   "dependencies": {
-    "cpx": "^1.5.0",
     "chalk": "^1.1.3",
-    "less-css-stream": "^1.0.0"
+    "cpx": "^1.5.0",
+    "less-css-stream": "^2.0.0"
+  },
+  "peerDependencies": {
+    "less": ">=1.0.0"
   }
 }


### PR DESCRIPTION
The version of lessc was locked on an older version by lessc-stream, I got lessc-stream to move the lessc to a peer dependency. This PR updates to the new lessc-stream and make lessc a peer dep for lessc-glob.

@sag1v 